### PR TITLE
ci: create workflow to alert telegram on release

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-actions:
+    name: Post-Release Actions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Notify Stakeholders on Release
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            New Release From Tag: ${{ github.ref }} Now Available! @dongkiat


### PR DESCRIPTION
## Description

Creates a workflow action that sends telegram notifications to stakeholders on release. This notification would also provide tag information.

## Screenshots
![image](https://user-images.githubusercontent.com/33172738/152358910-6ca9e152-4850-4b6e-a8d4-9397c39db725.png)
